### PR TITLE
Add missing semi-colon

### DIFF
--- a/ox-quarto.el
+++ b/ox-quarto.el
@@ -1,4 +1,4 @@
-;; ox-quarto.el --- Quarto Backend for Org Export Engine -*- lexical-binding: t; -*-
+;;; ox-quarto.el --- Quarto Backend for Org Export Engine -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2026 Jason Gantenberg
 ;; Author: Jason Gantenberg <jason.gantenberg@gmail.com>


### PR DESCRIPTION
The extra semi-colon is needed for use-package to recognize the mode.